### PR TITLE
bugfix 

### DIFF
--- a/build_ci.sh
+++ b/build_ci.sh
@@ -27,11 +27,11 @@ cppzmq_install() {
 
 runnerd_build() {
         cd $WORKDIR
-        mkdir build && cd build
+        mkdir build
+        cd build
         cmake ..
         make -j$PU
 }
-
 
 libzmq_install
 cppzmq_install


### PR DESCRIPTION
bugfix  in build script: if dir 'build' exist the command 'mkdir build && cd build' does not work